### PR TITLE
 Support building Windows targets on Linux build host

### DIFF
--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -34,7 +34,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include <quazip/JlCompress.h>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 void TestJlCompress::compressFile_data()


### PR DESCRIPTION
A few minor issues when trying to build Windows binaries from a Linux Host (i,e. Qt with MinGW on Ubuntu).

 1. `#include <Windows.h>` should be `#include <windows.h>` as Linux paths are case sensitive and is all lowercase in MinGW.

**P.S.** Releated to https://github.com/LibrePCB/LibrePCB/pull/234 and https://github.com/LibrePCB/LibrePCB/issues/235